### PR TITLE
Add codex guidance templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ The goal of this template is to maintain modularity and separation of concerns:
    cookiecutter gh:HoareLea/ds-project-template
    ```
 
+## Template Options
+The prompt set is intended to keep generated projects lean while preserving Hoare Lea defaults. The main toggles are:
+
+- `include_codex_scaffolding`: include `AGENTS.md` plus `tasks/todo.md`, `tasks/lessons.md`, and `tasks/decisions.md`
+- `include_streamlit_app`: include a starter Streamlit app with Hoare Lea branding under `app_streamlit/`
+- `include_fastapi_app`: include a starter FastAPI app under `app_fastapi/`
+- `azure_ml_project`: include Azure ML assets, jobs, and helper utilities
+- `database_type`: include database utility code and matching dependencies
+
+If `include_codex_scaffolding=no`, the generated project will not include `AGENTS.md` or `tasks/`.
+
 ## Technologies
 This project template comes with several tools designed to improve code quality and development efficiency. Some tools are included by default, while others are optional and can be chosen during the setup process.
 - **[Jupyter](https://jupyter.org/)**: Jupyter Notebooks are a popular tool for data exploration and communication. They allow you to write and run code in an interactive environment, which is particularly useful for data analysis and visualization. Note that Jupyter is intended for exploration and not for production code.
@@ -32,6 +43,7 @@ Pre-commit hooks are scripts that run automatically before you make a commit in 
 
 #### Optional Tools
 During the setup process, you can choose to include the following optional tools. If selected, relevant boilerplate code and configuration will be added to your project.
+- **Codex Scaffolding**: Adds a repo-local `AGENTS.md` plus `tasks/` tracking files so Codex has project-specific instructions, task state, lessons, and decisions inside the generated repository.
 - **[Azure ML](https://azure.microsoft.com/en-us/products/machine-learning)**: Azure Machine Learning is the preferred service for performing data science work at Hoare Lea. It can be used to provision compute and storage resources and has features for supporting the full ML lifecycle.
 - **[Streamlit](https://streamlit.io/)**: Streamlit is a framework for creating web applications from Python scripts. It is especially useful for creating interactive data applications and dashboards with minimal effort. Including Streamlit allows you to build and share interactive data apps quickly.
 - **[FastAPI](https://fastapi.tiangolo.com/)**: FastAPI is a modern, fast (high-performance) web framework for building APIs with Python. It is designed for creating RESTful APIs easily and efficiently. If you need to expose your models or data processing as APIs, FastAPI is a great choice.
@@ -41,6 +53,7 @@ During the setup process, you can choose to include the following optional tools
 The directory structure of your new project looks like this:
 ```
 ├── .env                   <- Local secrets and credentials that should not be stored in source control.
+├── AGENTS.md              <- Optional repo-local Codex instructions for the generated project.
 ├── Makefile               <- Makefile with useful commands for project setup and running analysis.
 ├── README.md              <- The top-level README for developers using this project.
 ├── app                    <- App-specific code, requirements file and Dockerfile.
@@ -65,5 +78,17 @@ The directory structure of your new project looks like this:
 │       ├── model          <- Scripts to train models and make predictions.
 │       ├── utils          <- Utility functions.
 │       └── visualization  <- Scripts to create exploratory and results-oriented visualizations.
+├── tasks                  <- Optional repo-local Codex task tracking, lessons, and decisions.
 └── tests                  <- Tests for functions in src.
 ```
+
+Optional prompts remove their corresponding files and folders during generation.
+
+## Codex Support
+
+If you enable `include_codex_scaffolding`, the generated project includes lightweight Codex support files that are meant to remain useful even on machines without the same global `~/.codex` setup.
+
+- `AGENTS.md`: project-specific Hoare Lea guidance for commands, structure, Azure ML, data handling, and verification
+- `tasks/todo.md`: a lightweight plan/progress file for substantial tasks
+- `tasks/lessons.md`: repo-specific corrections and recurring gotchas
+- `tasks/decisions.md`: notable architectural, modelling, or workflow decisions

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,7 @@
     "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
     "package_name": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
     "minimum_python_version": "3.10",
+    "include_codex_scaffolding": "yes",
     "include_streamlit_app": "yes",
     "include_fastapi_app": "yes",
     "azure_ml_project": "yes",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,12 +1,18 @@
 import os
 import shutil
 
+include_codex_scaffolding = "{{cookiecutter.include_codex_scaffolding}}"
 include_streamlit_app = "{{cookiecutter.include_streamlit_app}}"
 include_fastapi_app = "{{cookiecutter.include_fastapi_app}}"
 azure_ml_project = "{{cookiecutter.azure_ml_project}}"
 
 proj_path = os.getcwd()
 utils_dir = os.path.join(proj_path, "src", "{{cookiecutter.package_name}}", "utils")
+
+# Remove Codex scaffolding if not selected
+if include_codex_scaffolding.lower() not in ['yes', 'y']:
+    os.remove(os.path.join(proj_path, 'AGENTS.md'))
+    shutil.rmtree(os.path.join(proj_path, 'tasks'))
 
 # Remove unnecessary app templates
 if include_streamlit_app.lower() not in ['yes', 'y']:

--- a/{{ cookiecutter.repo_name }}/AGENTS.md
+++ b/{{ cookiecutter.repo_name }}/AGENTS.md
@@ -1,0 +1,75 @@
+# Repository Instructions
+
+These instructions add Hoare Lea project-specific context on top of any global Codex instructions.
+Keep this file focused on information that is true for this generated project; avoid restating generic workflow guidance that already lives in `~/.codex`, `README.md`, or the `Makefile`.
+
+## Project overview
+
+Describe the actual Hoare Lea project here. Keep it short and concrete: the client or internal team, what the repo produces, the expected outputs, and what correct work looks like.
+
+## Commands
+
+- Treat `README.md` and `Makefile` as the source of truth for setup, test, lint, and run commands.
+- Document only non-obvious or project-specific commands here when they exist.
+- Prefer `make setup` for initial setup, `make test` for tests, and `uv run ...` for targeted Python commands unless the project documents a different workflow.
+
+## Working defaults
+
+- Prefer small, correct, reviewable changes over broad rewrites.
+- Inspect existing code, tests, config, notebooks, and docs before guessing about project behavior.
+- Find root causes before patching symptoms unless the task explicitly asks for a temporary workaround.
+- Do not add production dependencies, change public interfaces, or restructure major folders without a clear project-specific reason.
+{% if cookiecutter.include_streamlit_app in ['yes', 'y', 'YES', 'Y'] %}- Keep Hoare Lea Streamlit styling, assets, and visual conventions intact when editing app code.
+{% endif %}
+
+## Architecture
+
+- `src/{{ cookiecutter.package_name }}/`: reusable project code; prefer putting durable logic here
+- `tests/`: unit tests for code in `src/`
+- `notebooks/`: exploration and communication; refactor stable logic back into `src/`
+- `conf/`: versioned configuration
+- `data/`: local data split into raw, intermediate, model input, and model output stages
+{% if cookiecutter.azure_ml_project in ['yes', 'y', 'YES', 'Y'] %}- `azureml/`: Azure ML assets, environment setup, data registration, jobs, and pipeline-related scripts
+{% endif %}
+- `models/`: trained artifacts or model summaries
+{% if cookiecutter.include_streamlit_app in ['yes', 'y', 'YES', 'Y'] %}- `app_streamlit/`: Streamlit app scaffold using Hoare Lea branding and styles
+- `assets/`: Hoare Lea app assets such as logos and static styling resources
+{% endif %}{% if cookiecutter.include_fastapi_app in ['yes', 'y', 'YES', 'Y'] %}- `app_fastapi/`: FastAPI app scaffold
+{% endif %}
+- `tasks/`: repo-local task tracking for substantial Codex work
+
+## Task tracking
+
+- Use `tasks/todo.md` for substantial tasks that involve multiple steps, debugging, cross-cutting edits, or meaningful verification.
+- Read `tasks/decisions.md` before changing architecture, public interfaces, data contracts, modelling assumptions, workflow patterns, or other areas where prior decisions may constrain the change.
+- Add an entry to `tasks/decisions.md` when the work introduces or reverses an important architectural, product, modelling, or workflow decision.
+- Use `tasks/lessons.md` for repo-specific corrections, recurring gotchas, or reusable mistakes that should change future work in this repo.
+
+## Conventions
+
+- Keep reusable domain logic out of notebooks and app entry points when practical.
+- Prefer extending existing modules under `src/{{ cookiecutter.package_name }}/` before adding parallel helpers.
+- Treat raw data as immutable and keep transformations explicit in code.
+- Add or update tests for non-trivial behavior changes.
+- Keep documentation up to date when behavior, setup, commands, configuration, data assumptions, or user-facing workflows change.
+{% if cookiecutter.azure_ml_project in ['yes', 'y', 'YES', 'Y'] %}- For Azure ML work, keep workspace-specific settings in config or environment variables rather than hard-coding them in reusable modules.
+- Be careful with secrets passed to Azure ML command jobs; use Key Vault or managed identity patterns when secrets are involved.
+{% endif %}
+
+## Risk notes
+
+- Do not commit `.env`, local data, secrets, credentials, or generated model artifacts unless the task explicitly requires it.
+- Do not edit generated or derived outputs directly when the source code, config, or pipeline should change instead.
+- Keep repo-level instructions specific to this project and avoid repeating generic Codex behavior from global settings.
+
+## Verification expectations
+
+Before saying done, run the most relevant subset of:
+
+```bash
+make test
+uv build
+```
+
+For linting or formatting, use the commands documented in this repo's `Makefile` and `README.md`.
+Add extra validation commands here if this project adopts them. Do not claim completion without verification; if something cannot be run, explain exactly what was blocked and what should be run next.

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -4,6 +4,9 @@
 ## Project Structure
 ```
 ├── .env                   <- Local config and secrets that should not be stored in source control.
+{% if cookiecutter.include_codex_scaffolding in ['yes', 'y', 'YES', 'Y'] -%}
+├── AGENTS.md              <- Repo-local Codex instructions for this project.
+{% endif -%}
 ├── Makefile               <- Makefile with useful commands for project setup and running analysis.
 ├── README.md              <- The top-level README for developers using this project.
 ├── app                    <- App-specific code, requirements file and Dockerfile.
@@ -28,6 +31,9 @@
 │       ├── model          <- Scripts to train models and make predictions.
 │       ├── utils          <- Utility functions.
 │       └── visualization  <- Scripts to create exploratory and results-oriented visualizations.
+{% if cookiecutter.include_codex_scaffolding in ['yes', 'y', 'YES', 'Y'] -%}
+├── tasks                  <- Repo-local task tracking, lessons, and decisions for substantial Codex work.
+{% endif -%}
 └── tests                  <- Tests for functions in src.
 ```
 
@@ -54,6 +60,22 @@
 4. **Update Environment Variables**:
 Much of the codebase is reliant on environment variables. Set any relevant variables in the `.env` file.
 **Please Note: You can define secrets in `.env` but note that any variables passed in the definition of an Azure ML command job will be exposed. In this case, use Key Vault.**
+
+{% if cookiecutter.include_codex_scaffolding in ['yes', 'y', 'YES', 'Y'] -%}
+### Codex Support Files
+
+This project includes optional repo-local Codex scaffolding:
+
+- `AGENTS.md`: project-specific Hoare Lea instructions that complement any global `~/.codex` settings
+- `tasks/todo.md`: a lightweight plan/progress file for substantial tasks
+- `tasks/lessons.md`: repo-specific lessons and recurring gotchas
+- `tasks/decisions.md`: notable architectural, modelling, or workflow decisions
+
+If you plan to use Codex in this repo, update `AGENTS.md` early and replace the placeholder sections with the real project context, datasets, outputs, constraints, and any important local conventions.
+
+These files make the repo more self-contained when used across machines with different Codex global configuration.
+
+{% endif -%}
 
 ### Usage
 

--- a/{{ cookiecutter.repo_name }}/tasks/decisions.md
+++ b/{{ cookiecutter.repo_name }}/tasks/decisions.md
@@ -1,0 +1,15 @@
+# Project Decisions
+
+Record important architectural, product, modelling, or workflow decisions.
+
+## Template
+
+### YYYY-MM-DD - Decision title
+
+Decision:
+
+Context:
+
+Alternatives considered:
+
+Consequences:

--- a/{{ cookiecutter.repo_name }}/tasks/lessons.md
+++ b/{{ cookiecutter.repo_name }}/tasks/lessons.md
@@ -1,0 +1,21 @@
+# Repo Lessons
+
+Use this file for repo-specific lessons learned from corrections, bugs, failed attempts, or recurring gotchas.
+
+Good entries are concrete and reusable.
+
+## Template
+
+### YYYY-MM-DD - Short title
+
+Lesson:
+
+- ...
+
+Why it matters:
+
+- ...
+
+Future rule:
+
+- ...

--- a/{{ cookiecutter.repo_name }}/tasks/todo.md
+++ b/{{ cookiecutter.repo_name }}/tasks/todo.md
@@ -1,0 +1,18 @@
+# Task Plan
+
+Use this file for substantial tasks only. Do not maintain it for tiny one-shot edits.
+
+## Current task
+
+- [ ] Define task
+- [ ] Inspect relevant files
+- [ ] Plan implementation
+- [ ] Implement
+- [ ] Verify
+- [ ] Summarize result
+
+## Review
+
+- Changed files:
+- Verification run:
+- Remaining risks:


### PR DESCRIPTION
## Summary

Adds optional Codex scaffolding to the Hoare Lea data science project template. These are some lightweight repo-local files I’ve been using and finding useful for keeping Codex work more consistent across projects.

## Changes

- Added a new `include_codex_scaffolding` Cookiecutter prompt, defaulting to `yes`.
- Added generated `AGENTS.md` guidance adapted for Hoare Lea projects, including Azure ML, app styling, data handling, verification, and keeping docs up to date.
- Added a generated `tasks/` directory with:
  - `todo.md` for task plans and progress
  - `lessons.md` for repo-specific gotchas
  - `decisions.md` for important project decisions
- Updated the post-generation hook so opting out removes `AGENTS.md` and `tasks/`.
- Updated template documentation and generated project README content to explain the new option.

## Verification

- Rendered sample projects with Codex scaffolding enabled and disabled.
- Confirmed opt-out removes the Codex files and README references.